### PR TITLE
docs: Update image placeholders in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Module could be used independently or together with [Chainlink External Adapters
 
 Where:
 
-- ![#DAE8FC](https://via.placeholder.com/15/DAE8FC/DAE8FC.png) Covered by this Chainlink Node terraform [module](https://github.com/orionterra/terraform-aws-chainlink-node)
-- ![#D5E8D4](https://via.placeholder.com/15/D5E8D4/D5E8D4.png) Covered by Chainlink External Adapters terraform [module](https://github.com/orionterra/terraform-aws-chainlink-ea)
-- ![#D0CEE2](https://via.placeholder.com/15/D0CEE2/D0CEE2.png) Covered by RDS community terraform [module](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora)
-- ![#FFE6CC](https://via.placeholder.com/15/FFE6CC/FFE6CC.png) Covered by VPC community terraform [module](https://github.com/terraform-aws-modules/terraform-aws-vpc)
+- ![#DAE8FC](https://placehold.co/15x15/DAE8FC/DAE8FC.png) Covered by this Chainlink Node terraform [module](https://github.com/orionterra/terraform-aws-chainlink-node)
+- ![#D5E8D4](https://placehold.co/15x15/D5E8D4/D5E8D4.png) Covered by Chainlink External Adapters terraform [module](https://github.com/orionterra/terraform-aws-chainlink-ea)
+- ![#D0CEE2](https://placehold.co/15x15/D0CEE2/D0CEE2.png) Covered by RDS community terraform [module](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora)
+- ![#FFE6CC](https://placehold.co/15x15/FFE6CC/FFE6CC.png) Covered by VPC community terraform [module](https://github.com/terraform-aws-modules/terraform-aws-vpc)
 
 ## Usage
 


### PR DESCRIPTION
## Description

Fixes broken color indicator icons in the README/documentation. The previous placeholder service (`via.placeholder.com`) is no longer rendering the color blocks, resulting in broken image links. 

<img width="858" height="249" alt="image" src="https://github.com/user-attachments/assets/776d2dfb-bab4-4794-9ef8-fd61b3e4799e" />

Updated the image sources to a reliable alternative service (`placehold.co`) to restore the visual layout and correctly display the module color-coding.

## Changes
- Updated image URLs for all four architectural component color indicators.

<img width="918" height="245" alt="image" src="https://github.com/user-attachments/assets/d49a3dcd-c5cc-4034-a7db-a0e89f6a15ab" />
